### PR TITLE
[CodeScribe] Corrige exclusion .spec et avertissement

### DIFF
--- a/codescribe.py
+++ b/codescribe.py
@@ -248,7 +248,7 @@ def gather_project_tree(root_path: str,
             _, ext = os.path.splitext(file_name)
             if ext.lower() in included_exts:
                 # Si --ignore-spec est activé, on ignore les .spec.ts
-                if ignore_spec and file_name.endswith(".spec.ts"):
+                if ignore_spec and file_name.lower().endswith(".spec.ts"):
                     continue
 
                 # Construire le chemin relatif pour l'affichage
@@ -330,11 +330,11 @@ def generate_markdown_report(root_path: str,
     # Logo ASCII (si --no-logo n'est pas précisé)
     if not no_logo:
         lines.append(
-            """```
-       _____          _       _____           _ _          
-      / ____|        | |     / ____|         (_) |         
-     | |     ___   __| | ___| (___   ___ _ __ _| |__   ___ 
-     | |    / _ \ / _` |/ _ \\___ \ / __| '__| | '_ \ / _ \\
+            r"""```
+       _____          _       _____           _ _
+      / ____|        | |     / ____|         (_) |
+     | |     ___   __| | ___| (___   ___ _ __ _| |__   ___
+     | |    / _ \ / _` |/ _ \\___ \ / __| '__| | '_ \ / _ \
      | |___| (_) | (_| |  __/____) | (__| |  | | |_) |  __/
       \_____\___/ \__,_|\___|_____/ \___|_|  |_|_.__/ \___|
     ```"""

--- a/tests/test_codescribe.py
+++ b/tests/test_codescribe.py
@@ -25,8 +25,9 @@ def sample_project(tmp_path):
     # Fichier Python "métier"
     (proj_dir / "main.py").write_text("#!/usr/bin/env python3\nprint('Hello World')\n")
 
-    # Fichier spec.ts (devrait être ignoré si --ignore-spec)
+    # Fichiers spec.ts (devraient être ignorés si --ignore-spec)
     (proj_dir / "useless.spec.ts").write_text("describe('Useless', () => {});\n")
+    (proj_dir / "AnotherFile.SPEC.ts").write_text("describe('Upper', () => {});\n")
 
     # Un package-lock.json, par ex. (à ignorer si --minimal)
     (proj_dir / "package-lock.json").write_text("{}")
@@ -112,8 +113,9 @@ def test_codescribe_ignore_spec(sample_project, tmp_path):
     assert result.returncode == 0
 
     content = output_md.read_text(encoding="utf-8")
-    # useless.spec.ts ne devrait pas être présent
+    # Les fichiers .spec.ts ne doivent pas être présents
     assert "useless.spec.ts" not in content, "Le fichier .spec.ts doit être exclu en --ignore-spec"
+    assert "AnotherFile.SPEC.ts" not in content, "La vérification doit être insensible à la casse"
 
 
 def test_codescribe_max_size(sample_project, tmp_path):


### PR DESCRIPTION
## Summary
- handle `--ignore-spec` in a case-insensitive way
- avoid Python warnings for ASCII logo
- adjust tests for case-insensitive `.spec.ts` handling

## Testing
- `pytest -q`