### PR TITLE
[CodeScribe] ajout options version et default-ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,9 @@ Toutes les modifications notables seront listées ici.
 - Version initiale de CodeScribe.
 - Export des projets C#, Angular, Python en Markdown.
 - Options `--export-txt`, `--ignore-spec`, `--minimal`, `--txt`
+
+## [1.1.0] - 2024-04-10
+- Ajout de l'option `--exclude-ext` pour exclure des extensions.
+
+## [1.2.0] - 2024-04-11
+- Ajout des options `--version` et `--default-ext`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 - **Option `--max-size`** pour limiter la lecture des fichiers volumineux.
 - **Option `--ignore-spec`** pour ignorer les tests `*.spec.ts`.
 - **Option `--include-ext`** pour ajouter d'autres extensions à analyser.
+- **Option `--exclude-ext`** pour exclure des extensions spécifiques.
+- **Option `--version`** pour afficher la version actuelle.
+- **Option `--default-ext`** pour lister les extensions incluses par défaut.
 - **Option `--no-logo`** pour retirer le logo ASCII dans la sortie.
 - **Mode `--txt` ou `--export-txt`** pour obtenir un rapport texte.
 - **Paramètre `--output`** pour choisir le nom du fichier généré.
@@ -40,6 +43,15 @@ codescribe --source /path/to/myproject --output monrapport.md
 
 # Ignorer les fichiers de test Angular
 codescribe --source /path/to/myproject --ignore-spec
+
+# Exclure certaines extensions
+codescribe --source /path/to/myproject --exclude-ext .log .tmp
+
+# Afficher la version
+codescribe --version
+
+# Lister les extensions par défaut
+codescribe --default-ext
 
 # Aide complète
 codescribe --help

--- a/tests/test_codescribe.py
+++ b/tests/test_codescribe.py
@@ -185,3 +185,58 @@ def test_codescribe_txt_only(sample_project, tmp_path):
     # Vérifier qu'aucun fichier .md n'a été généré
     possible_md = tmp_path / "export_only.md"
     assert not possible_md.exists(), "Aucun fichier .md ne doit être généré en mode --txt seulement"
+
+
+def test_codescribe_exclude_ext(sample_project, tmp_path):
+    """Vérifie l'option --exclude-ext."""
+    output_md = tmp_path / "export_exclude.md"
+    cmd = [
+        "python", "codescribe.py",
+        "--source", str(sample_project),
+        "--exclude-ext", ".py",
+        "--output", str(output_md)
+    ]
+    result = subprocess.run(cmd, capture_output=True)
+    assert result.returncode == 0
+
+    content = output_md.read_text(encoding="utf-8")
+    assert "main.py" not in content
+    assert "bigfile.py" not in content
+    assert "Program.cs" in content
+
+
+def test_codescribe_version_option():
+    """Vérifie l'option --version."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("codescribe", "codescribe.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = subprocess.run([
+        "python",
+        "codescribe.py",
+        "--version",
+    ], capture_output=True)
+    assert result.returncode == 0
+    assert module.__version__ in result.stdout.decode()
+
+
+def test_codescribe_default_ext_option():
+    """Vérifie l'option --default-ext."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("codescribe", "codescribe.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = subprocess.run([
+        "python",
+        "codescribe.py",
+        "--default-ext",
+    ], capture_output=True)
+    assert result.returncode == 0
+    out = result.stdout.decode()
+    # Chaque extension attendue doit apparaître
+    for ext in module.DEFAULT_INCLUDED_EXT:
+        assert ext in out


### PR DESCRIPTION
## Summary
- add `--version` and `--default-ext` options
- document the new CLI flags in README
- update changelog for version 1.2.0
- test `--version` and `--default-ext` options

## Testing
- `pytest -q`